### PR TITLE
measure the duration with a monotonic clock

### DIFF
--- a/src/Network/Datadog/Trace.hs
+++ b/src/Network/Datadog/Trace.hs
@@ -202,10 +202,7 @@ startSpan info traceId = do
   -- Now that we asked for a parent, put ourselves on top so that
   -- nested spans see us as the parent.
   span_id <- liftIO Random.randomIO
-  -- DataDog wants a epoch timestamp for their UI but we need a
-  -- monotonic time to measure the duration interval. So we get both.
-  startTime <- liftIO $ Clock.getTime Clock.Realtime
-  startTimeMonotonic <- liftIO $ Clock.getTime Clock.Monotonic
+  startTime <- liftIO $ Clock.getTime Clock.Monotonic
   let s = Span { _span_trace_id = traceId
                , _span_span_id = span_id
                , _span_name = _span_info_name info
@@ -228,8 +225,14 @@ startSpan info traceId = do
 -- in-flight messages for each sender.
 endSpan :: (MonadIO m, MonadTrace m) => RunningSpan -> m ()
 endSpan s = do
+  !curTime <- liftIO $ Clock.getTime Clock.Realtime
   !endTime <- liftIO $ Clock.getTime Clock.Monotonic
-  let !finishedSpan = s { _span_duration = fromIntegral (Clock.toNanoSecs endTime) - _span_start_monotonic s }
+  let
+    !duration = fromIntegral (Clock.toNanoSecs endTime) - _span_start s
+    !finishedSpan = s { _span_duration = duration
+                      -- restore span_start based on the epoch timestamp
+                      , _span_start = fromIntegral (Clock.toNanoSecs curTime) - duration
+                      }
   -- Send span off to all the workers. Do nothing alse as 'span' will
   -- take care of resetting the state.
   workers <- _trace_workers <$> askTraceState

--- a/src/Network/Datadog/Trace.hs
+++ b/src/Network/Datadog/Trace.hs
@@ -210,7 +210,6 @@ startSpan info traceId = do
                , _span_service = _span_info_service info
                , _span_type = _span_info_type info
                , _span_start = fromIntegral $ Clock.toNanoSecs startTime
-               , _span_start_monotonic = fromIntegral $ Clock.toNanoSecs startTimeMonotonic
                , _span_duration = ()
                , _span_parent_id = parent_span_id
                , _span_error = Nothing

--- a/src/Network/Datadog/Trace.hs
+++ b/src/Network/Datadog/Trace.hs
@@ -224,8 +224,8 @@ startSpan info traceId = do
 -- in-flight messages for each sender.
 endSpan :: (MonadIO m, MonadTrace m) => RunningSpan -> m ()
 endSpan s = do
-  !curTime <- liftIO $ Clock.getTime Clock.Realtime
   !endTime <- liftIO $ Clock.getTime Clock.Monotonic
+  !curTime <- liftIO $ Clock.getTime Clock.Realtime
   let
     !duration = fromIntegral (Clock.toNanoSecs endTime) - _span_start s
     !finishedSpan = s { _span_duration = duration

--- a/src/Network/Datadog/Trace/Types.hs
+++ b/src/Network/Datadog/Trace/Types.hs
@@ -60,6 +60,8 @@ data Span a = Span
   , _span_type :: !Text
     -- | The start time of the request in nanoseconds from the unix epoch.
   , _span_start :: !Word64
+    -- | The start time of the request in monotonic nanoseconds (to measure the duration).
+  , _span_start_monotonic :: !Word64
     -- | The duration of the request in nanoseconds.
   , _span_duration :: !a
     -- | The span integer ID of the parent span.

--- a/src/Network/Datadog/Trace/Types.hs
+++ b/src/Network/Datadog/Trace/Types.hs
@@ -60,8 +60,6 @@ data Span a = Span
   , _span_type :: !Text
     -- | The start time of the request in nanoseconds from the unix epoch.
   , _span_start :: !Word64
-    -- | The start time of the request in monotonic nanoseconds (to measure the duration).
-  , _span_start_monotonic :: !Word64
     -- | The duration of the request in nanoseconds.
   , _span_duration :: !a
     -- | The span integer ID of the parent span.


### PR DESCRIPTION
This ensures that the measured duration will not be negative due to
system clock adjustements.